### PR TITLE
Update track types

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ await vrt.trackPage(page, imageName[, options])
 await vrt.trackElementHandle(elementHandle, imageName[, options])
 ```
 
-- `elementHandle` <[ElementHandle](https://playwright.dev/#version=v1.4.0&path=docs%2Fapi.md&q=class-elementhandle)> Playwright ElementHandle
+- `elementHandle` <[ElementHandle](https://playwright.dev/docs/api/class-elementhandle)|[Locator](https://playwright.dev/docs/api/class-locator)> Playwright ElementHandle or Locator
 - `imageName` <[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type)> name for the taken screenshot image
 - `options` <[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)> optional configuration with:
 - - `diffTollerancePercent` <[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type)> specify acceptable difference from baseline, between `0-100`.

--- a/lib/playwright.interfaces.ts
+++ b/lib/playwright.interfaces.ts
@@ -1,60 +1,6 @@
 import { IgnoreArea } from "@visual-regression-tracker/sdk-js";
-
-export interface ElementHandleScreenshotOptions {
-  /**
-   * Hides default white background and allows capturing screenshots with transparency. Not applicable to `jpeg` images. Defaults to `false`.
-   */
-  omitBackground?: boolean;
-
-  /**
-   * Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the browserContext.setDefaultTimeout(timeout) or page.setDefaultTimeout(timeout) methods.
-   */
-  timeout?: number;
-}
-
-export interface PageScreenshotOptionsClip {
-  /**
-   * x-coordinate of top-left corner of clip area
-   */
-  x: number;
-
-  /**
-   * y-coordinate of top-left corner of clip area
-   */
-  y: number;
-
-  /**
-   * width of clipping area
-   */
-  width: number;
-
-  /**
-   * height of clipping area
-   */
-  height: number;
-}
-
-export interface PageScreenshotOptions {
-  /**
-   * When true, takes a screenshot of the full scrollable page, instead of the currently visibvle viewport. Defaults to `false`.
-   */
-  fullPage: boolean;
-
-  /**
-   * An object which specifies clipping of the resulting image. Should have the following fields:
-   */
-  clip?: PageScreenshotOptionsClip;
-
-  /**
-   * Hides default white background and allows capturing screenshots with transparency. Not applicable to `jpeg` images. Defaults to `false`.
-   */
-  omitBackground?: boolean;
-
-  /**
-   * Maximum time in milliseconds, defaults to 30 seconds, pass `0` to disable timeout. The default value can be changed by using the browserContext.setDefaultTimeout(timeout) or page.setDefaultTimeout(timeout) methods.
-   */
-  timeout?: number;
-}
+import { ElementHandle } from "playwright-core";
+import { Page } from "@playwright/test";
 
 export interface Agent {
   os?: string;
@@ -70,9 +16,9 @@ interface BaseTrackOptions {
 }
 
 export interface PageTrackOptions extends BaseTrackOptions {
-  screenshotOptions?: PageScreenshotOptions;
+  screenshotOptions?: Parameters<Page["screenshot"]>[0];
 }
 
 export interface ElementHandleTrackOptions extends BaseTrackOptions {
-  screenshotOptions?: ElementHandleScreenshotOptions;
+  screenshotOptions?: Parameters<ElementHandle["screenshot"]>[0];
 }

--- a/lib/playwrightVisualRegressionTracker.ts
+++ b/lib/playwrightVisualRegressionTracker.ts
@@ -3,7 +3,7 @@ import {
   BuildResponse,
   Config,
 } from "@visual-regression-tracker/sdk-js";
-import { Page, ElementHandle } from "@playwright/test";
+import { Page, ElementHandle, Locator } from "@playwright/test";
 import {
   PageTrackOptions,
   ElementHandleTrackOptions,
@@ -54,7 +54,7 @@ export class PlaywrightVisualRegressionTracker {
   }
 
   async trackElementHandle(
-    elementHandle: ElementHandle | null,
+    elementHandle: ElementHandle | Locator | null,
     name: string,
     options?: ElementHandleTrackOptions,
     retryCount = 2


### PR DESCRIPTION
1. I changed parameter (element type) of the trackElementHandle function. Use Locator has a right way in playwright to find elements. 
2. I changed screenshotOptions to the original functions parameters in playwright. So that they are always relevant and coincide with the real ones. 


3. I would also change the name of the function from trackElementHandle to trackElement it would be more universal. But this move to break backwards compatibility, but we can add alias and use both. 